### PR TITLE
feat: shared elasticsearch mounts

### DIFF
--- a/tutorforum/patches/k8s-deployments
+++ b/tutorforum/patches/k8s-deployments
@@ -17,14 +17,31 @@ spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
+      {%- if GROVE_ENABLE_SHARED_ELASTICSEARCH %}
+      volumes:
+        - name: elasticsearch-ca
+          configMap:
+            name: elasticsearch-ca
+      {%- endif %}
       containers:
         - name: forum
+          {%- if GROVE_ENABLE_SHARED_ELASTICSEARCH %}
+          volumeMounts:
+            - name: elasticsearch-ca
+              mountPath: /etc/ssl/certs/elasticsearch-ca.pem
+              subPath: elasticsearch-ca.pem
+              readOnly: false
+          {%- endif %}
           image: {{ FORUM_DOCKER_IMAGE }}
           ports:
             - containerPort: {{ FORUM_PORT }}
           env:
             - name: SEARCH_SERVER
+            {%- if ELASTICSEARCH_HTTP_AUTH|default('') %}
+              value: "{{ ELASTICSEARCH_SCHEME }}://{{ELASTICSEARCH_HTTP_AUTH}}@{{ ELASTICSEARCH_HOST }}:{{ ELASTICSEARCH_PORT }}"
+            {%- else %}
               value: "{{ ELASTICSEARCH_SCHEME }}://{{ ELASTICSEARCH_HOST }}:{{ ELASTICSEARCH_PORT }}"
+            {%-endif %}
             - name: MONGODB_AUTH
               value: "{% if MONGODB_USERNAME and MONGODB_PASSWORD %}{{ MONGODB_USERNAME}}:{{ MONGODB_PASSWORD }}@{% endif %}"
             - name: MONGODB_HOST
@@ -41,3 +58,7 @@ spec:
               value: "{{ MONGODB_AUTH_MECHANISM|auth_mech_as_ruby }}"
             - name: ELASTICSEARCH_INDEX_PREFIX
               value: "{{ ELASTICSEARCH_INDEX_PREFIX|default("") }}"
+            {%- if GROVE_ENABLE_SHARED_ELASTICSEARCH %}
+            - name: ELASTICSEARCH_CA_PATH
+              value: /etc/ssl/certs/elasticsearch-ca.pem
+            {%- endif %}

--- a/tutorforum/patches/k8s-jobs
+++ b/tutorforum/patches/k8s-jobs
@@ -9,12 +9,29 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      {%- if GROVE_ENABLE_SHARED_ELASTICSEARCH %}
+      volumes:
+        - name: elasticsearch-ca
+          configMap:
+            name: elasticsearch-ca
+      {%- endif %}
       containers:
       - name: forum
+        {%- if GROVE_ENABLE_SHARED_ELASTICSEARCH %}
+        volumeMounts:
+          - name: elasticsearch-ca
+            mountPath: /etc/ssl/certs/elasticsearch-ca.pem
+            subPath: elasticsearch-ca.pem
+            readOnly: false
+        {%- endif %}
         image: {{ FORUM_DOCKER_IMAGE }}
         env:
           - name: SEARCH_SERVER
+          {%- if ELASTICSEARCH_HTTP_AUTH|default('') %}
+            value: "{{ ELASTICSEARCH_SCHEME }}://{{ELASTICSEARCH_HTTP_AUTH}}@{{ ELASTICSEARCH_HOST }}:{{ ELASTICSEARCH_PORT }}"
+          {%- else %}
             value: "{{ ELASTICSEARCH_SCHEME }}://{{ ELASTICSEARCH_HOST }}:{{ ELASTICSEARCH_PORT }}"
+          {%-endif %}
           - name: MONGODB_AUTH
             value: "{% if MONGODB_USERNAME and MONGODB_PASSWORD %}{{ MONGODB_USERNAME}}:{{ MONGODB_PASSWORD }}@{% endif %}"
           - name: MONGODB_HOST
@@ -31,3 +48,7 @@ spec:
             value: "{{ MONGODB_AUTH_MECHANISM|auth_mech_as_ruby }}"
           - name: ELASTICSEARCH_INDEX_PREFIX
             value: "{{ ELASTICSEARCH_INDEX_PREFIX|default("") }}"
+          {%- if GROVE_ENABLE_SHARED_ELASTICSEARCH %}
+          - name: ELASTICSEARCH_CA_PATH
+            value: /etc/ssl/certs/elasticsearch-ca.pem
+          {%- endif %}


### PR DESCRIPTION
This PR is a placeholder for the changes required for Shared ElasticSearch on the forum.

Specifically, in order to have valid SSL termination, we mount the CA certificate on the pods so that it can communicate with ES.

This PR cannot be upstreamed and the changes should be part of `tutor-contrib-grove`. However they can't be added until https://github.com/overhangio/tutor/issues/791 is resolved.